### PR TITLE
Fix various errors and warnings related to http vs. https

### DIFF
--- a/nunjucks/templates/base.html
+++ b/nunjucks/templates/base.html
@@ -65,7 +65,7 @@
       <li class="nav__list-item nav__list-item--bottom"><a class="nav__link nav__link--bottom" href="/about/" tabindex="7"><span class="nav__link-text nav__link-text--bottom">About us</span></a></li>
     </ul>
   </footer>
-	{% block endbody %}{% endblock %}
 	<script src="/window.bundle.js"></script>
+	{% block endbody %}{% endblock %}
 </body>
 </html>

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -55,3 +55,7 @@ function addNavEvents() {
 }
 
 addNavEvents();
+
+(window as any).YTConfig = {
+  host: "https://www.youtube.com"
+};


### PR DESCRIPTION
Fix error, "Failed to execute 'postMessage' on 'DOMWindow'..." according to [https://github.com/troybetz/react-youtube/issues/96](https://github.com/troybetz/react-youtube/issues/96)